### PR TITLE
Implement _get_batches_of_transformed_samples

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     install_requires=[
         "click",
         "javabridge",
-        "Keras",
+        "Keras>=2.1.0",
         "keras-resnet>=0.0.7",
         "numpy",
         "python-bioformats",


### PR DESCRIPTION
Resolves #24 

Subclasses of `keras.preprocessing.image.Iterator` must implement `_get_batches_of_transformed_samples` in Keras >= 2.1.0