### PR TITLE
Pin Keras to 2.1.5

### DIFF
--- a/deepometry/image/iterator.py
+++ b/deepometry/image/iterator.py
@@ -61,6 +61,11 @@ class NumpyArrayIterator(keras.preprocessing.image.Iterator):
         for i, j in enumerate(index_array):
             x = self.x[j]
 
+            # `image_data_generator.preprocessing_function` call moved from `image_data_generator.standardize` in 2.1.5
+            # Moved back to `image_data_generator.standardize` in a later release.
+            if self.image_data_generator.preprocessing_function:
+                x = self.image_data_generator.preprocessing_function(x)
+
             x = self.image_data_generator.random_transform(x.astype(keras.backend.floatx()))
 
             x = self.image_data_generator.standardize(x)

--- a/deepometry/model.py
+++ b/deepometry/model.py
@@ -162,7 +162,7 @@ class Model(object):
         generator_options = {
             "height_shift_range": 0.5,
             "horizontal_flip": True,
-            "preprocessing_function": lambda data: data - means,
+            "preprocessing_function": lambda data: ((data - means + 255.0) / (2.0 * 255.0)),
             "rotation_range": 180,
             "vertical_flip": True,
             "width_shift_range": 0.5

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     install_requires=[
         "click",
         "javabridge",
-        "Keras>=2.1.0",
+        "Keras==2.1.5",  # TODO: See deepometry.iterator.NumpyArrayIterator's `_get_batches_of_transformed_samples`.
         "keras-resnet>=0.0.7",
         "numpy",
         "python-bioformats",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -110,9 +110,9 @@ def test_fit_defaults(data_dir, mocker):
         sample = x_train[0]
 
         expected = numpy.empty((48, 48, 3))
-        expected[:, :, 0] = sample[:, :, 0] - numpy.mean(x_train[:, :, :, 0])
-        expected[:, :, 1] = sample[:, :, 1] - numpy.mean(x_train[:, :, :, 1])
-        expected[:, :, 2] = sample[:, :, 2] - numpy.mean(x_train[:, :, :, 2])
+        expected[:, :, 0] = (sample[:, :, 0] - numpy.mean(x_train[:, :, :, 0]) + 255.0) / (2.0 * 255.0)
+        expected[:, :, 1] = (sample[:, :, 1] - numpy.mean(x_train[:, :, :, 1]) + 255.0) / (2.0 * 255.0)
+        expected[:, :, 2] = (sample[:, :, 2] - numpy.mean(x_train[:, :, :, 2]) + 255.0) / (2.0 * 255.0)
 
         actual = generator.image_data_generator.preprocessing_function(sample)
 
@@ -133,9 +133,9 @@ def test_fit_defaults(data_dir, mocker):
         sample = x_valid[0]
 
         expected = numpy.empty((48, 48, 3))
-        expected[:, :, 0] = sample[:, :, 0] - numpy.mean(x_train[:, :, :, 0])
-        expected[:, :, 1] = sample[:, :, 1] - numpy.mean(x_train[:, :, :, 1])
-        expected[:, :, 2] = sample[:, :, 2] - numpy.mean(x_train[:, :, :, 2])
+        expected[:, :, 0] = (sample[:, :, 0] - numpy.mean(x_train[:, :, :, 0]) + 255.0) / (2.0 * 255.0)
+        expected[:, :, 1] = (sample[:, :, 1] - numpy.mean(x_train[:, :, :, 1]) + 255.0) / (2.0 * 255.0)
+        expected[:, :, 2] = (sample[:, :, 2] - numpy.mean(x_train[:, :, :, 2]) + 255.0) / (2.0 * 255.0)
 
         actual = generator.image_data_generator.preprocessing_function(sample)
 


### PR DESCRIPTION
Supercool one-off release where the image generator's preprocession_function is called in the iterator's next method, rather than the image generator's standardize function. Of course, this is fixed in the unreleased version of Keras, and not an issue prior to 2.1.5.