### PR TITLE
More robust sampling

### DIFF
--- a/deepometry/parse.py
+++ b/deepometry/parse.py
@@ -156,7 +156,7 @@ def _crop(x, crop_width):
 def _clip(x):
     vmin, vmax = scipy.stats.scoreatpercentile(x, (0.5, 99.5))
 
-    return skimage.exposure.rescale_intensity(x, in_range=(vmin, vmax))
+    return numpy.clip(x, vmin, vmax)
 
 
 def _pad(x, pad_width):
@@ -185,7 +185,10 @@ def _convert(x):
     if x.dtype == numpy.uint8:
         return x
 
-    return skimage.img_as_ubyte(x)
+    return skimage.exposure.rescale_intensity(
+        x,
+        out_range=numpy.uint8
+    ).astype(numpy.uint8)
 
 
 def _pad_normal(vector, pad_width, iaxis, kwargs):

--- a/deepometry/parse.py
+++ b/deepometry/parse.py
@@ -137,13 +137,16 @@ def _resize(x, size):
     clipped = _clip(cropped)
 
     # Pad
-    return _pad(
+    padded = _pad(
         clipped,
         pad_width=(
             numpy.maximum((column_adjust_start, column_adjust_end), (0, 0)),
             numpy.maximum((row_adjust_start, row_adjust_end), (0, 0))
         )
     )
+
+    # Convert to uint-8
+    return _convert(padded)
 
 
 def _crop(x, crop_width):
@@ -176,6 +179,13 @@ def _pad(x, pad_width):
     mean = means[idx]
 
     return numpy.pad(x, pad_width, _pad_normal, mean=mean, std=std)
+
+
+def _convert(x):
+    if x.dtype == numpy.uint8:
+        return x
+
+    return skimage.img_as_ubyte(x)
 
 
 def _pad_normal(vector, pad_width, iaxis, kwargs):


### PR DESCRIPTION
Sample the corner with the lowest standard deviation. Pad the image with random noise generated from the corner's mean and standard deviation.

Additionally, reorganize preprocessing operations to reduce noise from omitted pixels:

1. Crop the image such that the dimensions are no more than the desired size.
2. Clip the pixels in the 0.5th and 99.5th percentile, reducing noise in the cropped image.
3. Pad the image with random noise sampled from the mean and standard deviation of the corner with the lowest standard deviation.
4. Stretch the image from (image.min, image.max) to (0, 256), and save as uint8.
